### PR TITLE
log and exit if programmer is not specified correctly

### DIFF
--- a/modules/nina/main.go
+++ b/modules/nina/main.go
@@ -43,9 +43,10 @@ func Run(ctx context.Context) {
 
 	if strings.Contains(filepath.Base(ctx.ProgrammerPath), "bossac") {
 		programmer = &bossac.Bossac{}
-	}
-	if strings.Contains(filepath.Base(ctx.ProgrammerPath), "avrdude") {
+	} else if strings.Contains(filepath.Base(ctx.ProgrammerPath), "avrdude") {
 		programmer = &avrdude.Avrdude{}
+	} else {
+		log.Fatal("Programmer path not specified correctly, programmer path set to: " + ctx.ProgrammerPath)
 	}
 
 	if ctx.FWUploaderBinary != "" {


### PR DESCRIPTION
During a bug 🐛  hunt with @AlbyIanna we discovered that on windows (*obviously*), if paths are not specified correctly the FirmwareUpdater was crashing with a panic (`panic: runtime error: invalid memory address or nil pointer dereference`). The problem was that the flag `-programmer` was indicating something meaningless like `C:/Users/Umberto`.